### PR TITLE
Various fixes and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Open KSUploader.jar, right-click on icon in the system tray, settings, and setup
 
 OR
 
-Open and edit the `client.properties` file saved in `Appdata\Roaming\.ksuploader` on Windows, in your user home in the folder `.ksuploader` on Linux, then launch the client again.
+Open and edit the `client.properties` file saved in `Appdata\Roaming\.ksuploader` on Windows, in your user home in the folder `.ksuploader` on Linux or in `~/Library/Application Support/.ksuploader` on OS X, then launch the client again.
 It contains:
 * `server_address`: the address where there is the server, you can use a domain (example.com) or an ip.
 * `password`: the password of the server that will be used during the authentication check.

--- a/src/it/ksuploader/dialogs/PopupDialog.java
+++ b/src/it/ksuploader/dialogs/PopupDialog.java
@@ -5,7 +5,6 @@ import it.ksuploader.main.Main;
 import javax.swing.*;
 import java.awt.*;
 import java.awt.event.MouseAdapter;
-import java.awt.geom.RoundRectangle2D;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -142,14 +141,7 @@ public class PopupDialog extends Observable {
 		messageLabel.setText(message);
 		dialogFrame.setAlwaysOnTop(true);
 
-		if (message.length() > 30) {
-			int width = (message.length() * 6);
-			dialogFrame.setSize(width, 50);
-			dialogFrame.setShape(new RoundRectangle2D.Double(1, 1, width, 50, 20, 20));
-		} else {
-			dialogFrame.setSize(200, 50);
-			dialogFrame.setShape(new RoundRectangle2D.Double(1, 1, 200, 50, 20, 20));
-		}
+		dialogFrame.pack();
 		this.autoPosition();
 	}
 

--- a/src/it/ksuploader/main/MyScreen.java
+++ b/src/it/ksuploader/main/MyScreen.java
@@ -42,13 +42,6 @@ public class MyScreen extends JPanel {
 
 			@Override
 			public void mouseReleased(MouseEvent e) {
-				if (startPoint.x + startPoint.y < e.getX() + e.getY()) {
-					selectionBounds.setBounds(startPoint.x++, startPoint.y++, e.getX() - startPoint.x--,
-							e.getY() - startPoint.y--);
-				} else {
-					selectionBounds.setBounds(e.getX() + 1, e.getX() + 1, startPoint.x - e.getX() - 1,
-							startPoint.y - e.getX() - 1);
-				}
 				panel.removeAll();
 				panel.dispose();
 

--- a/src/it/ksuploader/main/MyScreen.java
+++ b/src/it/ksuploader/main/MyScreen.java
@@ -27,6 +27,9 @@ public class MyScreen extends JPanel {
 		this.selectionBounds = new Rectangle();
 		JDialog panel = new JDialog();
 
+		panel.setUndecorated(true);
+		panel.setOpacity(0.5f);
+
 		MouseAdapter mouseHandler = new MouseAdapter() {
 			@Override
 			public void mouseClicked(MouseEvent e) {

--- a/src/it/ksuploader/main/MyScreen.java
+++ b/src/it/ksuploader/main/MyScreen.java
@@ -126,6 +126,6 @@ public class MyScreen extends JPanel {
 	}
 
 	public boolean isValidScreen() {
-		return (selectionBounds == null || selectionBounds.width <= 2 || selectionBounds.height <= 2);
+		return !(selectionBounds == null || selectionBounds.width <= 2 || selectionBounds.height <= 2);
 	}
 }

--- a/src/it/ksuploader/main/SocketUploader.java
+++ b/src/it/ksuploader/main/SocketUploader.java
@@ -104,12 +104,11 @@ public class SocketUploader implements Observer {
 			return false;
 		} finally {
 			try {
-				inChannel.close();
-				aFile.close();
-				dis.close();
-				dos.flush();
-				dos.close();
-				socketChannel.close();
+				if (inChannel != null) inChannel.close();
+				if (aFile != null) aFile.close();
+				if (dis != null) dis.close();
+				if (dos != null && socketChannel != null) dos.close();
+				if (socketChannel != null) socketChannel.close();
 			} catch (IOException e) {
 				e.printStackTrace();
 			}
@@ -119,11 +118,11 @@ public class SocketUploader implements Observer {
 
 	public void stopUpload() {
 		try {
-			inChannel.close();
-			aFile.close();
-			dos.close();
-			dis.close();
-			socketChannel.close();
+			if (inChannel != null) inChannel.close();
+			if (aFile != null) aFile.close();
+			if (dos != null && socketChannel != null) dos.close();
+			if (dis != null) dis.close();
+			if (socketChannel != null) socketChannel.close();
 			new File(Main.so.getTempDir(), "KStemp.zip").delete();
 			Main.dialog.show("Stopped...", "", false);
 		} catch (IOException e) {

--- a/src/it/ksuploader/main/SystemTrayMenu.java
+++ b/src/it/ksuploader/main/SystemTrayMenu.java
@@ -189,7 +189,7 @@ public class SystemTrayMenu {
                 capturing = true;
                 MyScreen partialScreen = new MyScreen();
                 capturing = false;
-                if (partialScreen.isValidScreen()) {
+                if (!partialScreen.isValidScreen()) {
                     Main.dialog.show("Upload Cancelled!", ":(", false);
                     Main.dialog.destroy();
                 } else {


### PR DESCRIPTION
Fixed some issues with the client. Most notably:
- The area capture function (making a screenshot of part of the computer window) didn't work: when selecting, it only showed a black area on a gray background. b77adc5b7a40fc54708617becc2b1fe156ed61ee
  ![black_capture_issue](https://cloud.githubusercontent.com/assets/11180733/15621674/cfc038a0-2462-11e6-857c-ac13ac6f0659.jpg)
- The bounds of the rectangle used for the area capture function were being incorrectly registered, which caused that some perfectly fine screenshots couldn't be uploaded. e4612555cdb8093d6f2331d0f4039927628f143d

Some of these issues may have been platform-dependent. I have encountered them on OS X 10.11.5.

Please look in the commit descriptions for detailed information regarding each fix.

P.S. This may be very obvious, but why is it called KSUploader? What does KS stand for? :smile:
